### PR TITLE
Fix for savestate problems

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -366,7 +366,6 @@ void copy_file(char * ininame, char * fileName)
 
 void retro_init(void)
 {
-    uint64_t serialization_quirks = RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE;
     char* sys_pathname;
     wchar_t w_pathname[PATH_SIZE];
     environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &sys_pathname);
@@ -395,7 +394,6 @@ void retro_init(void)
 
     environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &colorMode);
     environ_cb(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumble);
-    environ_cb(RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS, &serialization_quirks);
     initializing = true;
 
     retro_thread = co_active();
@@ -934,13 +932,7 @@ bool retro_serialize(void *data, size_t size)
     if (initializing)
         return false;
 
-    const char* filename = ConfigGetSharedDataFilepath("savestate.temp");
-    int success = savestates_save_m64p((char*)filename);
-    FILE *read_ptr;
-    read_ptr = fopen(filename, "rb");
-    int read_size = fread(data, size, 1, read_ptr);
-    fclose(read_ptr);
-    remove(filename);
+    int success = savestates_save_m64p(data);
     if (success)
         return true;
 
@@ -952,13 +944,7 @@ bool retro_unserialize(const void * data, size_t size)
     if (initializing)
         return false;
 
-    FILE *write_ptr;
-    const char* filename = ConfigGetSharedDataFilepath("savestate.temp");
-    write_ptr = fopen(filename,"wb");
-    fwrite(data, size, 1, write_ptr);
-    fclose(write_ptr);
-    int success = savestates_load_m64p((char*)filename);
-    remove(filename);
+    int success = savestates_load_m64p(data);
     if (success)
         return true;
 

--- a/mupen64plus-core/src/main/savestates.h
+++ b/mupen64plus-core/src/main/savestates.h
@@ -48,8 +48,13 @@ void savestates_deinit(void);
 int savestates_load(void);
 int savestates_save(void);
 
+#ifdef __LIBRETRO__
+int savestates_save_m64p(void *data);
+int savestates_load_m64p(const void *data);
+#else
 int savestates_save_m64p(char *filepath);
 int savestates_load_m64p(char *filepath);
+#endif
 
 void savestates_select_slot(unsigned int s);
 unsigned int savestates_get_slot(void);


### PR DESCRIPTION
This should hopefully fix all the problems surrounding save states and netplay.

Perhaps @fr500 and @orbea can test this out to make sure it doesn't break anything with current save states?

@orbea this should also fix the issue you are having with your controller I would assume.

Hopefully this is minor enough that it can be accepted into mupen64plus-core, everything new is wrapped inside \_\_LIBRETRO\_\_ ifdefs so it shouldn't affect the current operation of upstream mupen64plus